### PR TITLE
Handle Exception for category tree

### DIFF
--- a/Helper/Categories/CategoryHelper.php
+++ b/Helper/Categories/CategoryHelper.php
@@ -225,7 +225,12 @@ class CategoryHelper
 
         if (!empty($categoryIds)) {
             foreach ($categoryIds as $categoryId) {
+                try{
                 $productCategory = $this->categoryRepository->get($categoryId, $storeId);
+                }catch(\Exception $e){
+                 $this->logger->error($e->getMessage());
+                }
+
                 if (!$productCategory || !$this->canCategoryBeReindex($productCategory, $storeId))
                     continue;
 
@@ -256,6 +261,7 @@ class CategoryHelper
         }
 
         $categoriesData["_categories"] = array_values(array_unique($categoriesData["_categories"]));
+        $categoriesData["categories_path"]= array_values(array_unique($categoriesData["categories_path"]));
         return $categoriesData;
     }
 


### PR DESCRIPTION
Here we resolve the case where 2 or more category tree exists in the in-store 